### PR TITLE
Fixes the secret updater and remove uncessary reconciation

### DIFF
--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -191,7 +191,7 @@ func patchBuild(ctx context.Context, patchHelper *patch.Helper, build *buildv1.B
 func (r *BuildReconciler) reconcile(ctx context.Context, build *buildv1.Build) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	if build.Status.Ready {
-		log.Info("Skipping Reconcilation because the build image is done and The Infrastructure is cleaned up.")
+		log.Info("Skipping Reconciliation because the build image is done and The Infrastructure is cleaned up.")
 		return ctrl.Result{}, nil
 	}
 	phases := []func(context.Context, *buildv1.Build) (ctrl.Result, error){

--- a/internal/controller/build_controller.go
+++ b/internal/controller/build_controller.go
@@ -486,12 +486,12 @@ func (r *BuildReconciler) reconcileConnection(ctx context.Context, build *buildv
 
 	// Skip checking if the Infrastructure not ready.
 	if !build.Status.InfrastructureReady {
-		log.V(4).Info("Skipping reconcileConnection because Infrastructure not ready yet")
+		log.Info("Skipping reconcileConnection because Infrastructure not ready yet")
 		return ctrl.Result{}, nil
 	}
 
 	if build.Spec.Connector.Credentials == nil {
-		log.V(4).Info("Skipping reconcileConnection because secret is not yet set")
+		log.Info("Skipping reconcileConnection because secret is not yet set")
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -33,6 +33,10 @@ func (r *BuildReconciler) reconcilePhase(_ context.Context, build *buildv1.Build
 		build.Status.SetTypedPhase(buildv1.BuildPhaseTerminating)
 	}
 
+	if build.Status.Ready {
+		build.Status.SetTypedPhase(buildv1.BuildPhaseCompleted)
+	}
+
 	// Only record the event if the status has changed
 	if preReconcilePhase != build.Status.GetTypedPhase() {
 		// Failed clusters should get a Warning event

--- a/pkg/ssh/publickey.go
+++ b/pkg/ssh/publickey.go
@@ -11,12 +11,13 @@ import (
 )
 
 // GetCredentialsFromSecret returns the public key from a private key in PEM format.
-func GetCredentialsFromSecret(secret *corev1.Secret) (username, password, privateKey string) {
+func GetCredentialsFromSecret(secret *corev1.Secret) (username, password, privateKey, publicKey string) {
 	username = string(secret.Data["username"])
 	password = string(secret.Data["password"])
 	privateKey = string(secret.Data["privateKey"])
+	publicKey = string(secret.Data["publicKey"])
 
-	return username, password, privateKey
+	return username, password, privateKey, publicKey
 }
 
 func GetPublicKeyFromPrivateKey(privateKeyPem string) (string, error) {

--- a/provisioner/shell/controller/reconcile.go
+++ b/provisioner/shell/controller/reconcile.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	ShellProvisionerRepo = "ghcr.io/forge-build/forge-provisioner-shell"
-	ShellProvisionerTag  = "latest"
+	ShellProvisionerTag  = "dev"
 
 	ForgeCoreNamespace = "forge-core"
 )
@@ -34,9 +34,8 @@ func Reconcile(ctx context.Context, client client.Client, build *buildv1.Build, 
 			WithBuildNamespace(build.Namespace).
 			WithBuildName(build.Name).
 			WithUUID(id.String()).
-			// TODO get repo and tag from variables
-			WithRepo("ghcr.io/mohamed-rafraf/forge-provisioner-shell").
-			WithTag("v0.0.1").
+			WithRepo(ShellProvisionerRepo).
+			WithTag(ShellProvisionerTag).
 			WithBackOffLimit(ptr.Deref(spec.Retries, 1)).
 			WithSSHCredentialsSecretName(build.Spec.Connector.Credentials.Name)
 

--- a/provisioner/shell/controller/reconcile.go
+++ b/provisioner/shell/controller/reconcile.go
@@ -35,8 +35,8 @@ func Reconcile(ctx context.Context, client client.Client, build *buildv1.Build, 
 			WithBuildName(build.Name).
 			WithUUID(id.String()).
 			// TODO get repo and tag from variables
-			WithRepo("medchiheb/forge-shell-provisioner").
-			WithTag("dev").
+			WithRepo("ghcr.io/mohamed-rafraf/forge-provisioner-shell").
+			WithTag("v0.0.1").
 			WithBackOffLimit(ptr.Deref(spec.Retries, 1)).
 			WithSSHCredentialsSecretName(build.Spec.Connector.Credentials.Name)
 


### PR DESCRIPTION
### What This PR Fixes:
- **Secret Update Issue:** Fixes `EnsureCredentialsSecret` to properly update an existing secret instead of leaving it unchanged after creation.
- **Unnecessary Reconciliation:** Skips reconciliation for provisioners and connection checks if the build is already completed and infrastructure is cleaned up.
- **Removed Unnecessary Logic:** Removes `reconcileImageProvided`, as image build events are handled by provider extensions once `provisionerReady` is true. 

This streamlines the reconciliation process and avoids redundant operations.